### PR TITLE
Allow a default handler to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.2
 
 before_script:
+  - pecl install uopz
   - composer self-update
   - composer install -n
 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
+        "ext-uopz": "*",
         "phpunit/phpunit": "^6.0",
         "zendframework/zend-diactoros": "^1.3",
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/src/Whoops.php
+++ b/src/Whoops.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Whoops\Handler\HandlerInterface;
 use Whoops\Handler\JsonResponseHandler;
 use Whoops\Handler\PlainTextHandler;
 use Whoops\Handler\PrettyPageHandler;
@@ -25,6 +26,11 @@ class Whoops implements MiddlewareInterface
      * @var SystemFacade|null
      */
     private $system;
+
+    /**
+     * @var HandlerInterface|null
+     */
+    private $handler;
 
     /**
      * @var bool Whether catch errors or not
@@ -46,6 +52,20 @@ class Whoops implements MiddlewareInterface
     public function catchErrors(bool $catchErrors = true): self
     {
         $this->catchErrors = (bool) $catchErrors;
+
+        return $this;
+    }
+
+    /**
+     * Set the default handler to use (instead of the standard PrettyPrintHandler).
+     *
+     * @param HandlerInterface $handler The default handler to use
+     *
+     * @return $this
+     */
+    public function defaultHandler(HandlerInterface $handler)
+    {
+        $this->handler = $handler;
 
         return $this;
     }
@@ -129,7 +149,7 @@ class Whoops implements MiddlewareInterface
                 $handler->addTraceToOutput(true);
                 break;
             default:
-                $handler = new PrettyPageHandler();
+                $handler = $this->handler ?: new PrettyPageHandler();
                 break;
         }
 

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -6,11 +6,7 @@ namespace Middlewares\Tests;
 use Middlewares\Utils\Dispatcher;
 use Middlewares\Whoops;
 use PHPUnit\Framework\TestCase;
-use Whoops\Handler\CallbackHandler;
-use Whoops\Handler\JsonResponseHandler;
 use Whoops\Handler\XmlResponseHandler;
-use Zend\Diactoros\Request;
-use Zend\Diactoros\Response\EmptyResponse;
 use Zend\Diactoros\ServerRequest;
 use function uopz_set_return;
 use function uopz_unset_return;
@@ -91,5 +87,21 @@ class HandlerTest extends TestCase
 
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals('text/html', $response->getHeaderLine('Content-Type'));
+    }
+
+
+    public function testCustom()
+    {
+        $request = (new ServerRequest)->withHeader('Accept', 'text/html');
+
+        $response = Dispatcher::run([
+            (new Whoops)->defaultHandler(new XmlResponseHandler),
+            function () {
+                throw new \Exception('Error Processing Request');
+            },
+        ], $request);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('text/xml', $response->getHeaderLine('Content-Type'));
     }
 }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types = 1);
+
+namespace Middlewares\Tests;
+
+use Middlewares\Utils\Dispatcher;
+use Middlewares\Whoops;
+use PHPUnit\Framework\TestCase;
+use Whoops\Handler\CallbackHandler;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\XmlResponseHandler;
+use Zend\Diactoros\Request;
+use Zend\Diactoros\Response\EmptyResponse;
+use Zend\Diactoros\ServerRequest;
+use function uopz_set_return;
+use function uopz_unset_return;
+
+class HandlerTest extends TestCase
+{
+
+    public function setUp()
+    {
+        uopz_set_return("php_sapi_name", "phpunit");
+    }
+
+
+    public function tearDown()
+    {
+        uopz_unset_return("php_sapi_name");
+    }
+
+
+    public function testJson()
+    {
+        $request = (new ServerRequest)->withHeader('Accept', 'application/json');
+
+        $response = Dispatcher::run([
+            new Whoops(),
+            function () {
+                throw new \Exception('Error Processing Request');
+            },
+        ], $request);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+    }
+
+
+    public function testXml()
+    {
+        $request = (new ServerRequest)->withHeader('Accept', 'text/xml');
+
+        $response = Dispatcher::run([
+            new Whoops(),
+            function () {
+                throw new \Exception('Error Processing Request');
+            },
+        ], $request);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('text/xml', $response->getHeaderLine('Content-Type'));
+    }
+
+
+    public function testPlain()
+    {
+        $request = (new ServerRequest)->withHeader('Accept', 'text/plain');
+
+        $response = Dispatcher::run([
+            new Whoops(),
+            function () {
+                throw new \Exception('Error Processing Request');
+            },
+        ], $request);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('text/plain', $response->getHeaderLine('Content-Type'));
+    }
+
+
+    public function testDefault()
+    {
+        $request = (new ServerRequest)->withHeader('Accept', 'text/html');
+
+        $response = Dispatcher::run([
+            new Whoops(),
+            function () {
+                throw new \Exception('Error Processing Request');
+            },
+        ], $request);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('text/html', $response->getHeaderLine('Content-Type'));
+    }
+}


### PR DESCRIPTION
I want to take advantage of the content type guessing this library does, while at the same time specifying which editor the `PrettyPageHandler` should use.

This PR allows this behaviour by supporting a default handler to be used if no content specific one is in use