### PR TITLE
Fix PHPUnit deprecation warning

### DIFF
--- a/tests/WhoopsTest.php
+++ b/tests/WhoopsTest.php
@@ -36,7 +36,7 @@ class WhoopsTest extends TestCase
 
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals('text/plain', $response->getHeaderLine('Content-Type'));
-        $this->assertRegExp('/Undefined variable[:]? [$]?b/', (string) $response->getBody());
+        $this->assertEquals(1, preg_match('/Undefined variable[:]? [$]?b/', (string) $response->getBody()));
     }
 
     public function testNotError()


### PR DESCRIPTION
`assertRegExp` is deprecated in PHPUnit 9.4 but `assertMatchesRegularExpression` is not available in PHPUnit 8.1

This should fix travis build after #9